### PR TITLE
Implement build order script

### DIFF
--- a/accessibility.rb
+++ b/accessibility.rb
@@ -1,5 +1,5 @@
 module ADR
-  class Accessiblity
+  module Accessibility
     def speak message
       puts message
     end

--- a/build_order
+++ b/build_order
@@ -13,7 +13,7 @@ def determine_build_order(paths)
   build_context = parsed_files.map {|p| determine_definitions_and_references(p) }
 
   order = resolve_order(build_context)
-  puts order.join("\n")
+  puts order.map{|f| f[:name]}.join("\n")
 end
 
 def resolve_order(build_context)
@@ -32,10 +32,59 @@ def resolve_order(build_context)
     # if we loop twice over the same list, we raise an exception that a
     # circular dependency exists
     if resolved.empty?
-      raise "Circular dependency found: \n#{dependants.inspect}\nBuild order: #{build_order}
+      raise "Circular dependency found: \n#{dependants.inspect}\nBuild order: #{build_order.inspect}"
     else
       build_order += resolved
     end
+  end
+
+  build_order
+end
+
+def establish_dependencies(build_context)
+  definitions = {}
+  dependants = []
+
+  # we make a Hash of each definition, to the file it is defined in
+  build_context.each do |f|
+    add_definitions(definitions, f[:name], f[:definitions], "")
+  end
+
+  # for each reference in each file, we want to get the file that has it defined
+  build_context.each do |f|
+    references = f[:references]
+    dependants << {
+      name: f[:name],
+      dependencies: references.map {|r| get_dependency(definitions, r)}
+    }
+  end
+end
+
+def get_dependency(definitions, reference)
+  name, nesting = reference
+  if name.start_with? "::"
+    result = definitions[name]
+    raise "Could not find reference #{name}" unless result
+    return result
+  end
+
+  found = false
+  prefix = ""
+  loop do
+    result = definitions["::" + prefix + name]
+    return result if result
+    raise "Could not find reference #{name} (#{prefix}), in #{definitions.inspect}" if nesting.empty?
+    prefix += "::" + nesting.shift
+  end
+
+  raise "Could not find reference #{name}"
+end
+
+def add_definitions(definitions, filename, new_definitions, prefix)
+  new_definitions.each do |name, nested|
+    fullname = prefix + "::" + name
+    definitions[fullname] = filename # TODO multiple file definitions
+    add_definitions(definitions, filename, nested, fullname)
   end
 end
 
@@ -184,14 +233,14 @@ end
 def match_class(sexp)
   # [:class, [:const_ref ... ], nil, ... ]
   if sexp && sexp.first == :class
-    [resolve_name(sexp[1]), sexp[3][1]]
+    [] << resolve_name(sexp[1]) << sexp[3][1]
   end
 end
 
 def match_module(sexp)
   # [:module, [:const_ref ... ], ... ]
   if sexp && sexp.first == :module
-    [resolve_name(sexp[1]), sexp[2][1]]
+    [] << resolve_name(sexp[1]) << sexp[2][1]
   end
 end
 
@@ -201,7 +250,7 @@ end
 
 def resolve_name(sexp)
   if sexp[0] == :const_ref
-    # [:const_ref, [:@const, "View", [1, 6]]],
+    # [:const_ref, [:@const, "View", [1, 6]]]
     sexp[1][1]
   else
     raise "name not a const_ref"

--- a/build_order
+++ b/build_order
@@ -13,7 +13,7 @@ def determine_build_order(paths)
   build_context = parsed_files.map {|p| determine_definitions_and_references(p) }
 
   order = resolve_order(build_context)
-  puts order.map{|f| f[:name]}.join("\n")
+  puts order.join("\n")
 end
 
 def resolve_order(build_context)
@@ -26,7 +26,7 @@ def resolve_order(build_context)
   while !dependants.empty?
     # we loop over the ordered files, if a file has no dependencies that
     # are not in the final order, we add that file to the final order
-    resolved, dependants = build_order.partition do |dependant|
+    resolved, dependants = dependants.partition do |dependant|
       dependant[:dependencies].all? {|dependency| build_order.include? dependency}
     end
     # if we loop twice over the same list, we raise an exception that a
@@ -34,7 +34,7 @@ def resolve_order(build_context)
     if resolved.empty?
       raise "Circular dependency found: \n#{dependants.inspect}\nBuild order: #{build_order.inspect}"
     else
-      build_order += resolved
+      build_order += resolved.map {|d| d[:name]}
     end
   end
 
@@ -58,6 +58,8 @@ def establish_dependencies(build_context)
       dependencies: references.map {|r| get_dependency(definitions, r)}
     }
   end
+
+  dependants
 end
 
 def get_dependency(definitions, reference)
@@ -71,7 +73,8 @@ def get_dependency(definitions, reference)
   found = false
   prefix = ""
   loop do
-    result = definitions["::" + prefix + name]
+    fullname = prefix + "::" + name
+    result = definitions[fullname]
     return result if result
     raise "Could not find reference #{name} (#{prefix}), in #{definitions.inspect}" if nesting.empty?
     prefix += "::" + nesting.shift

--- a/build_order
+++ b/build_order
@@ -49,12 +49,14 @@ def scan(tree)
   # we want to match constants and ident references and add those to references
   tree.each do |sexp|
     next unless sexp
-    references =
+    found_references =
       match_class_inheritance(sexp) ||
       match_command(sexp) ||
       match_expression(sexp)
 
-    references.each do |reference|
+    next unless found_references
+
+    found_references.each do |reference|
       references << [reference,[]] if reference
     end
   end
@@ -77,8 +79,43 @@ def match_expression(sexp)
     match_call(sexp) ||
     match_top_const(sexp) ||
     match_var_ref(sexp) ||
-    match_assign(sexp)
-    nil # etc..
+    match_assign(sexp) ||
+    match_def_references(sexp) || # todo this isn't really an expression, but we'll have to modify the definitions thing to explore scopes without names or something to remove this here
+    [] # etc..
+end
+
+def match_def_references(sexp)
+  # [:def,
+  #   [:@ident, "initialize", [5, 8]],
+  #   [:params, nil, nil, nil, nil, nil, nil, nil],
+  #   [:bodystmt, [[:void_stmt]], nil, nil, nil]]
+  if sexp && sexp[0] == :def
+    params = sexp[2][1..-1] # Todo find consts in params
+    body = sexp[3][1]
+    body.map {|e| match_expression(e)}.flatten
+  end
+end
+
+def match_assign(sexp)
+  if sexp && sexp[0] == :assign
+    match_expression(sexp[1]) + match_expression(sexp[2])
+  end
+end
+
+def match_var_ref(sexp)
+  # [:var_ref, [:@const, "Game", [5, 12]]]
+  if sexp && sexp[0] == :var_ref
+    if sexp[1][0] == :@const
+      [] << sexp[1][1]
+    end
+  end
+end
+
+def match_top_const(sexp)
+  # [:top_const_ref, [:@const, "Accessiblity", [3, 14]]]
+  if sexp && sexp[0] == :top_const_ref
+    [] << "::" + sexp[1][1]
+  end
 end
 
 def match_call(sexp)
@@ -91,8 +128,10 @@ end
 def match_const_path(sexp)
   if sexp && sexp[0] == :const_path_ref
     # TODO what if it somehow references a constant that's not part of the
-    # const path? is that possible?
-    (match_expression(sexp[1) + sexp[2][1]).join("::")
+    # const path?
+    prefix = match_expression(sexp[1])
+    suffix = sexp[2][1]
+    [] << (prefix << suffix).join("::")
   end
 end
 
@@ -111,7 +150,11 @@ def match_class_inheritance(sexp)
 end
 
 def match_definition(sexp)
-  match_class(sexp) || match_module(sexp) || match_method(sexp) || match_constant(sexp)
+  match_class(sexp) || match_module(sexp) || match_constant(sexp) || match_method_definition(sexp)
+end
+
+def match_method_definition(sexp)
+  nil # todo
 end
 
 def match_class(sexp)
@@ -126,10 +169,6 @@ def match_module(sexp)
   if sexp && sexp.first == :module
     [resolve_name(sexp[1]), sexp[2][1]]
   end
-end
-
-def match_method(sexp)
-  false
 end
 
 def match_constant(sexp)

--- a/build_order
+++ b/build_order
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+require 'ripper'
+require 'pp'
+
+paths = ARGV.empty? ? ["."] : ARGV
+
+def determine_build_order(paths)
+  files = paths
+    .flat_map {|p| list_files(p) }
+    .select {|p| p.end_with?(".rb")}
+
+  parsed_files = files.map {|p| parse(p) }
+  build_context = parsed_files.map {|p| determine_definitions_and_references(p) }
+  pp build_context
+end
+
+def determine_definitions_and_references(file)
+  definitions_and_references = scan(file[:parsed][1]) # [:program, [..] ]
+
+
+  file.merge! definitions_and_references
+
+  file
+end
+
+def scan(tree)
+  # we want to match a module, a class, constant or method definition
+  # and add those to definitions
+  definitions = {}
+  tree.each do |sexp|
+    definition, body = match_definition(sexp)
+    if definition
+      definitions[definition] = {}
+      
+      if body
+        result = scan(body)
+        definitions[definition] = result[:definitions]
+        # TODO also merge references, they should have their scope associated
+      end
+    end
+  end
+
+  # we want to match constants and ident references and add those to references
+
+
+  # inside those matches we want to recurse to find more definitions and references
+
+  references = []
+  
+  {
+    definitions: definitions,
+    references: references
+  }
+end
+
+def match_definition(sexp)
+  match_class(sexp) || match_module(sexp) || match_method(sexp) || match_constant(sexp)
+end
+
+def match_class(sexp)
+  # [:class, [:const_ref ... ], nil, ... ]
+  if sexp && sexp.first == :class
+    [resolve_name(sexp[1]), sexp[3][1]]
+  end
+end
+
+def match_module(sexp)
+  # [:module, [:const_ref ... ], ... ]
+  if sexp && sexp.first == :module
+    [resolve_name(sexp[1]), sexp[2][1]]
+  end
+end
+
+def match_method(sexp)
+  false
+end
+
+def match_constant(sexp)
+  false
+end
+
+def resolve_name(sexp)
+  if sexp[0] == :const_ref
+    # [:const_ref, [:@const, "View", [1, 6]]],
+    sexp[1][1]
+  else
+    raise "name not a const_ref"
+  end
+rescue
+  puts "Could not resolve name: #{ sexp.inspect }"
+end
+
+def parse(file)
+  {
+    name: file,
+    parsed: Ripper.sexp(File.read(file)),
+    definitions: {},
+    references: {}
+  }
+end
+
+def list_files(path)
+  Dir.glob("#{path}/**/*")
+end
+
+determine_build_order(paths)

--- a/build_order
+++ b/build_order
@@ -27,6 +27,8 @@ def scan(tree)
   # we want to match a module, a class, constant or method definition
   # and add those to definitions
   definitions = {}
+  references = []
+
   tree.each do |sexp|
     definition, body = match_definition(sexp)
     if definition
@@ -35,22 +37,77 @@ def scan(tree)
       if body
         result = scan(body)
         definitions[definition] = result[:definitions]
-        # TODO also merge references, they should have their scope associated
+        result[:references].each do |r|
+          # Each reference is a tuple of the name of the reference, and
+          # its named scope
+          references << [r[0], r[1].unshift(definition)]
+        end
       end
     end
   end
 
   # we want to match constants and ident references and add those to references
+  tree.each do |sexp|
+    next unless sexp
+    references =
+      match_class_inheritance(sexp) ||
+      match_command(sexp) ||
+      match_expression(sexp)
 
+    references.each do |reference|
+      references << [reference,[]] if reference
+    end
+  end
 
   # inside those matches we want to recurse to find more definitions and references
 
-  references = []
   
   {
     definitions: definitions,
     references: references
   }
+end
+
+# Note these will have to be expressions that can be evaluated at compile time
+def match_expression(sexp)
+  # can a named scope be created inside an expression? if so
+  # then this means we're going to have to track both at the
+  # same time :(
+  match_const_path(sexp) ||
+    match_call(sexp) ||
+    match_top_const(sexp) ||
+    match_var_ref(sexp) ||
+    match_assign(sexp)
+    nil # etc..
+end
+
+def match_call(sexp)
+  if sexp && sexp[0] == :call
+    match_expression(sexp[1]) # TODO continue implementation
+  end
+end
+
+# [:const_path_ref, [:var_ref, [:@const, "B1", [1, 0]]], [:@const, "B2", [1, 4]]]
+def match_const_path(sexp)
+  if sexp && sexp[0] == :const_path_ref
+    # TODO what if it somehow references a constant that's not part of the
+    # const path? is that possible?
+    (match_expression(sexp[1) + sexp[2][1]).join("::")
+  end
+end
+
+def match_command(sexp)
+  if sexp && sexp[0] == :command
+    # TODO research what else can be in a command
+    args = sexp[2]
+    args[1].flat_map {|a| match_expression(a)}.compact
+  end
+end
+
+def match_class_inheritance(sexp)
+  if sexp && sexp.first == :class
+    match_expression(sexp[2]) # TODO untested
+  end
 end
 
 def match_definition(sexp)

--- a/build_order
+++ b/build_order
@@ -11,12 +11,36 @@ def determine_build_order(paths)
 
   parsed_files = files.map {|p| parse(p) }
   build_context = parsed_files.map {|p| determine_definitions_and_references(p) }
-  pp build_context
+
+  order = resolve_order(build_context)
+  puts order.join("\n")
+end
+
+def resolve_order(build_context)
+  # first we have to establish for each file which files it depends on
+  dependants = establish_dependencies(build_context)
+  # we sort by number of dependencies
+  dependants.sort! {|f1, f2| f1[:dependencies].length <=> f2[:dependencies].length }
+  # and create a list that will contain the final order
+  build_order = []
+  while !dependants.empty?
+    # we loop over the ordered files, if a file has no dependencies that
+    # are not in the final order, we add that file to the final order
+    resolved, dependants = build_order.partition do |dependant|
+      dependant[:dependencies].all? {|dependency| build_order.include? dependency}
+    end
+    # if we loop twice over the same list, we raise an exception that a
+    # circular dependency exists
+    if resolved.empty?
+      raise "Circular dependency found: \n#{dependants.inspect}\nBuild order: #{build_order}
+    else
+      build_order += resolved
+    end
+  end
 end
 
 def determine_definitions_and_references(file)
   definitions_and_references = scan(file[:parsed][1]) # [:program, [..] ]
-
 
   file.merge! definitions_and_references
 

--- a/game.rb
+++ b/game.rb
@@ -1,6 +1,6 @@
 module ADR
   class Game
-    include ::Accessiblity
+    include ADR::Accessibility
 
     def initialize
 

--- a/view.rb
+++ b/view.rb
@@ -1,7 +1,9 @@
-class View
-  include ADR::Accessiblity
+module ADR
+  class View
+    include ADR::Accessibility
 
-  def initialize
-    @game = Game.new
+    def initialize
+      @game = Game.new
+    end
   end
 end


### PR DESCRIPTION
This script uses Ripper to find constant references and definitions in Ruby files on a given path, it then determines an order in which the Ruby files can be loaded so that the constants are available for each file as it is loaded.